### PR TITLE
fix: unify function names to camel case in idParser

### DIFF
--- a/server/api/me/hooks.ts
+++ b/server/api/me/hooks.ts
@@ -1,6 +1,6 @@
 import type { UserModel } from '$/commonTypesWithClient/models';
 import { getUserModel } from '$/middleware/firebaseAdmin';
-import { UserIdParser } from '$/service/idParsers';
+import { userIdParser } from '$/service/idParsers';
 import { defineHooks } from './$relay';
 
 export type AdditionalRequest = {
@@ -17,7 +17,7 @@ export default defineHooks(() => ({
     }
 
     req.user = {
-      id: UserIdParser.parse(user.uid),
+      id: userIdParser.parse(user.uid),
       email: user.email ?? '',
       displayName: user.displayName,
       photoURL: user.photoURL,

--- a/server/service/idParsers.ts
+++ b/server/service/idParsers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { TaskId, UserId } from '../commonTypesWithClient/branded';
 
-export const UserIdParser: z.ZodType<UserId> = z.string().brand<'UserId'>();
+export const userIdParser: z.ZodType<UserId> = z.string().brand<'UserId'>();
 
 export const taskIdParser: z.ZodType<TaskId> = z.string().brand<'TaskId'>();


### PR DESCRIPTION
`UserIdPareser`と`taskIdParser`で関数の命名規則が統一されていないのが毎度気になっていたので修正しました。
この命名規則が意図的だった場合closeしてください。