### PR TITLE
fix: swap the order of lint and typecheck runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
         if: steps.client-npm-cache.outputs.cache-hit != 'true'
       - run: npm install --prefix server
         if: steps.server-npm-cache.outputs.cache-hit != 'true'
-      - run: npm run lint
       - run: npm run typecheck
+      - run: npm run lint
       - run: |
           cp client/.env.example client/.env
           cp server/.env.example server/.env


### PR DESCRIPTION
lint時にaspidaによる型の自動生成が行われないため、それに由来するエラーが発生する場合があった。
このPRでは、lintとtypecheckの順番を入れ替えることで、lintの前に自動生成が行われるように修正する。