### PR TITLE
fix: Update firebase emulator command 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - ./docker/dev/.env
     working_dir: /opt/workspace
-    command: firebase emulators:start --only=auth --project=emulator --import=seeder
+    command: firebase emulators:start --only=auth --project=emulator --import ./firebase-export --export-on-exit
 
   minio:
     image: minio/minio:RELEASE.2023-08-23T10-07-06Z


### PR DESCRIPTION
  firebase emulatorsの起動コマンドに
` --import ./firebase-export --export-on-exit ` を追記して終了時にエクスポートし、起動時にエクスポートしたファイルを読み込むようにしました

#4 