### PR TITLE
fix: Update firebase emulator command and Dockerfile

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - ./docker/dev/.env
     working_dir: /opt/workspace
-    command: firebase emulators:start --only=auth --project=emulator --import=seeder
+    command: firebase emulators:start --only=auth --project=emulator --import=seeder --export-on-exit
 
   minio:
     image: minio/minio:RELEASE.2023-08-23T10-07-06Z

--- a/docker/dev/firebase/Dockerfile
+++ b/docker/dev/firebase/Dockerfile
@@ -8,3 +8,4 @@ RUN ( \
 )
 RUN npm install -g firebase-tools
 COPY . /opt/workspace/
+COPY ./seeder /seeder


### PR DESCRIPTION
firebase emulatorsの起動コマンドを
command: firebase emulators:start --only=auth --project=emulator --import=seeder --export-on-exit
に変更し、Dockerfileで
COPY ./seeder /seeder
を追加し、初期アカウントの3アカウントをコピーしました。