### PR TITLE
add: Functionality to remove trailing slash from CORS_ORIGIN

### DIFF
--- a/server/service/envValues.ts
+++ b/server/service/envValues.ts
@@ -5,7 +5,7 @@ dotenv.config();
 
 const PORT = +z.string().regex(/^\d+$/).parse(process.env.PORT);
 const API_BASE_PATH = z.string().startsWith('/').parse(process.env.API_BASE_PATH);
-const CORS_ORIGIN = z.string().url().parse(process.env.CORS_ORIGIN);
+const CORS_ORIGIN = z.string().url().transform(url => url.replace(/\/$/, '')).parse(process.env.CORS_ORIGIN);
 const FIREBASE_AUTH_EMULATOR_HOST = z
   .string()
   .optional()


### PR DESCRIPTION
CORS_ORIGINのURLの末尾に/があり、デプロイ時にそれに気づかず悩む人を出さないために

.transform(url => url.replace(/\/$/, ''))部分を追加し
CORS_ORIGIN=http://localhost:3000/ でもCORS_ORIGIN=http://localhost:3000 と同じように動くようにしました。

この機能いらなかったらcloseしてください。