### PR TITLE
refactor: update the COPY command in the Dockerfile to copy the destination directory to './' instead of '.'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 
 WORKDIR /usr/src/app
 
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY client/package.json client/package-lock.json ./client/


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description
`Dockerfile`の`COPY`コマンドのディレクトリ指定は末尾が`/`で終わっていなければならないため以下を修正https://github.com/frouriojs/catapult/blob/52eeb89c32bbd919ded58c0c11c2fe24f57aaf18/Dockerfile#L5

### 表示されていたエラー
```
When using COPY with more than one source file, the destination must be a directory and end with a / or a \dockerfile-utils(23)
```
![Screenshot 2024-07-13 022143](https://github.com/user-attachments/assets/341e1b6e-2e14-4529-9d5d-3954469840ce)

### 参照: docker公式ドキュメントよりhttps://docs.docker.com/reference/dockerfile/#copy 
> If multiple resources are specified, either directly or due to the use of a wildcard, then must be a directory, and it must end with a slash .<src><dest>/
